### PR TITLE
Stop duplicate entry of sale stock detail. Check by dates of the saved record.

### DIFF
--- a/erpnext/distributor/doctype/sale_stock_detail/sale_stock_detail.js
+++ b/erpnext/distributor/doctype/sale_stock_detail/sale_stock_detail.js
@@ -52,6 +52,8 @@ frappe.ui.form.on('Sale Stock Detail', {
 		cur_frm.clear_table("selling_product");
 		cur_frm.refresh_fields();
 		let pdf_file = frm.doc.file;
+		let from_date = frm.doc.from;
+		let to_date = frm.doc.to;
 		if(frm.doc.city){
 			let dist_city = frm.doc.city;
 			frappe.call({
@@ -59,6 +61,8 @@ frappe.ui.form.on('Sale Stock Detail', {
 				args: {
 					'pdf_file': pdf_file,
 					'dist_city': dist_city,
+					'from_date': from_date,
+					'to_date': to_date,
 				},
 				callback: function (r) {
 					var info = r.message;

--- a/erpnext/distributor/doctype/sale_stock_detail/sale_stock_detail.py
+++ b/erpnext/distributor/doctype/sale_stock_detail/sale_stock_detail.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
 from __future__ import unicode_literals
+from datetime import date
 import frappe
 from frappe.model.document import Document
 import pdfplumber
@@ -15,11 +15,19 @@ class SaleStockDetail(Document):
     pass
 
 @frappe.whitelist(allow_guest=True)
-def parse_pdf(pdf_file,dist_city):
-    #print(pdf_file,dist_city)
+def parse_pdf(pdf_file,dist_city,from_date,to_date):
+    #print(pdf_file,dist_city,from_date,to_date)
     arr = re.split('/',pdf_file);
     path = frappe.get_site_path(arr[1],arr[2],arr[3]);
     #print(path)
+    dates_data = frappe.db.get_list('Sale Stock Detail',
+        filters={
+            'from': from_date,
+            'to': to_date
+        },
+        as_list=True)
+    if(dates_data):
+        frappe.throw(('Same dates record already exist'))       
     alldata = []
     require_data = []
     if(dist_city == "Abbotabad" or dist_city == "Bannu" or dist_city == "Jhelum" or dist_city == "Rawalpindi"):


### PR DESCRIPTION
I have written code to check on the dates of the Sale Stock Detail saved record. 

If 'from' date and 'to' date of Sale stock detail of new entry and saved record then error message showed "Same dates record already exist".

If not dates are the same then the Sale Stock Detail pdf is processed and the distributor saves the record in our system.